### PR TITLE
fix: use stakeholder data when putting stakeholder

### DIFF
--- a/backend/src/controllers/casedata/casedata-errand.controller.ts
+++ b/backend/src/controllers/casedata/casedata-errand.controller.ts
@@ -285,18 +285,18 @@ export class CaseDataErrandController {
 
     const administratorCheckedData = errandData;
 
-    const data = makeErrandApiData(administratorCheckedData, errandId.toString());
-    const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${data.id}`;
+    const errandApiData = makeErrandApiData(administratorCheckedData, errandId.toString());
+    const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${errandApiData.id}`;
     const baseURL = apiURL(this.SERVICE);
-    const strippedStakeholders = { ...data, stakeholders: [] };
+    const strippedStakeholders = { ...errandApiData, stakeholders: [] };
     const patchResponse = await this.apiService
       .patch<ErrandDTO, Partial<PatchErrandDTO>>({ url, baseURL, data: strippedStakeholders }, req.user)
       .then(errandPatchResponse => {
         const stakeholderPatchPromises =
-          data.stakeholders
+          errandApiData.stakeholders
             ?.filter(s => !s.id)
             .map(async (stakeholder, idx) => {
-              const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${data.id}/stakeholders`;
+              const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${errandApiData.id}/stakeholders`;
               const baseURL = apiURL(this.SERVICE);
               const patchStakeholder = () =>
                 this.apiService.patch<any, StakeholderDTO>({ url, baseURL, data: stakeholder }, req.user).catch(e => {
@@ -308,14 +308,13 @@ export class CaseDataErrandController {
             }) || [];
 
         const stakeholderPutPromises =
-          data.stakeholders
+          errandApiData.stakeholders
             ?.filter(s => s.id)
             .map(async (stakeholder, idx) => {
-              const data = stakeholder;
-              const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${data.id}/stakeholders/${stakeholder.id}`;
+              const url = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${errandApiData.id}/stakeholders/${stakeholder.id}`;
               const baseURL = apiURL(this.SERVICE);
               const putStakeholder = () =>
-                this.apiService.put<any, StakeholderDTO>({ url, baseURL, data }, req.user).catch(e => {
+                this.apiService.put<any, StakeholderDTO>({ url, baseURL, data: stakeholder }, req.user).catch(e => {
                   logger.error('Something went wrong when putting stakeholder');
                   logger.error(e);
                   throw e;


### PR DESCRIPTION
Bugg: fel id används - stakeholder-id istället för errand-id

Lösning: använd stakeholderdata när stakeholder ska sparas.

Testa genom att först spara en ärendeägare på ett ärende och därefter göra uppdateringar på ärendet. Med buggen sparades en ny ärendeägare varje gång ärendet uppdaterades pga att id inte matchade.

Jira: https://jira.sundsvall.se/browse/DRAKEN-2369

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
