### PR TITLE
feat: show stakeholder insatser on applicant card

### DIFF
--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -24,6 +24,10 @@ export const APIS = [
     name: 'partyassets',
     version: '6.5',
   },
+  {
+    name: 'jsonschema',
+    version: '1.0',
+  },
 ] as const;
 
 export function apiServiceName(name: string): string {

--- a/backend/src/controllers/partyassets.controller.ts
+++ b/backend/src/controllers/partyassets.controller.ts
@@ -1,0 +1,41 @@
+import { MUNICIPALITY_ID } from '@/config';
+import { apiServiceName } from '@/config/api-config';
+import { Asset } from '@/data-contracts/partyassets/data-contracts';
+import { RequestWithUser } from '@interfaces/auth.interface';
+import authMiddleware from '@middlewares/auth.middleware';
+import ApiService from '@services/api.service';
+import { logger } from '@utils/logger';
+import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
+import { OpenAPI } from 'routing-controllers-openapi';
+
+interface AssetsResponseData {
+  data: Asset[];
+  message: string;
+}
+
+@Controller()
+export class PartyAssetsController {
+  private apiService = new ApiService();
+  private readonly SERVICE = apiServiceName('partyassets');
+
+  /**
+   * List the assets ("insatser") registered for a given person/party.
+   *
+   * @param partyId The party (person) identifier to look up assets for. Equals
+   *   the `personId` resolved through the citizen search.
+   */
+  @Get('/partyassets/assets/:partyId')
+  @OpenAPI({ summary: 'List assets (insatser) for a given party/person' })
+  @UseBefore(authMiddleware)
+  async getAssetsByPartyId(@Req() req: RequestWithUser, @Param('partyId') partyId: string): Promise<AssetsResponseData> {
+    const params = new URLSearchParams({ partyId });
+
+    const url = `${this.SERVICE}/${MUNICIPALITY_ID}/assets?${params.toString()}`;
+    const res = await this.apiService.get<Asset[]>({ url }, req.user).catch(e => {
+      logger.error(`Error when fetching assets for party ${partyId}`);
+      throw e;
+    });
+
+    return { data: res.data, message: 'success' };
+  }
+}

--- a/backend/src/controllers/schema.controller.ts
+++ b/backend/src/controllers/schema.controller.ts
@@ -1,0 +1,66 @@
+import { MUNICIPALITY_ID } from '@/config';
+import { apiServiceName } from '@/config/api-config';
+import { RequestWithUser } from '@interfaces/auth.interface';
+import authMiddleware from '@middlewares/auth.middleware';
+import ApiService from '@services/api.service';
+import { logger } from '@utils/logger';
+import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
+import { OpenAPI } from 'routing-controllers-openapi';
+
+/**
+ * Shape returned by the JsonSchema API for a single schema / ui-schema. Only the
+ * fields consumed here are typed; `value` holds the actual JSON Schema document.
+ */
+interface JsonSchemaResource {
+  id?: string;
+  value?: Record<string, unknown>;
+}
+
+interface SchemaResponseData {
+  data: {
+    schema: Record<string, unknown>;
+    uiSchema: Record<string, unknown>;
+    schemaId: string;
+  };
+  message: string;
+}
+
+@Controller()
+export class SchemaController {
+  private apiService = new ApiService();
+  private readonly SERVICE = apiServiceName('jsonschema');
+
+  /** Best-effort fetch of a schema's ui-schema; returns `{}` when none exists. */
+  private async fetchUiSchema(schemaId: string, req: RequestWithUser): Promise<Record<string, unknown>> {
+    try {
+      const url = `${this.SERVICE}/${MUNICIPALITY_ID}/schemas/${schemaId}/ui-schema`;
+      const res = await this.apiService.get<JsonSchemaResource>({ url }, req.user);
+      return res.data.value ?? {};
+    } catch {
+      logger.info(`No UI schema found for ${schemaId}, using empty object`);
+      return {};
+    }
+  }
+
+  /**
+   * Fetch a JSON Schema (and its optional ui-schema) by id. Used to resolve the
+   * human-readable labels and enum titles of an asset's `jsonParameters`.
+   */
+  @Get('/schemas/:schemaId')
+  @OpenAPI({ summary: 'Fetch a JSON schema and its ui-schema by id' })
+  @UseBefore(authMiddleware)
+  async getSchemaById(@Req() req: RequestWithUser, @Param('schemaId') schemaId: string): Promise<SchemaResponseData> {
+    const url = `${this.SERVICE}/${MUNICIPALITY_ID}/schemas/${schemaId}`;
+    const res = await this.apiService.get<JsonSchemaResource>({ url }, req.user).catch(e => {
+      logger.error(`Error when fetching schema ${schemaId}`);
+      throw e;
+    });
+
+    const uiSchema = await this.fetchUiSchema(schemaId, req);
+
+    return {
+      data: { schema: res.data.value ?? {}, uiSchema, schemaId },
+      message: 'success',
+    };
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,8 @@ import validateEnv from '@utils/validateEnv';
 import { UserController } from './controllers/user.controller';
 import { HealthController } from './controllers/health.controller';
 import { AddressController } from './controllers/address.controller';
+import { PartyAssetsController } from './controllers/partyassets.controller';
+import { SchemaController } from './controllers/schema.controller';
 import { CaseDataAttachmentController } from './controllers/casedata/casedata-attachment.controller';
 import { CaseDataDecisionsController } from './controllers/casedata/casedata-decision.controller';
 import { CaseDataErrandController } from './controllers/casedata/casedata-errand.controller';
@@ -20,6 +22,8 @@ const app = new App([
   UserController,
   HealthController,
   AddressController,
+  PartyAssetsController,
+  SchemaController,
   CaseDataAttachmentController,
   CaseDataDecisionsController,
   CaseDataErrandController,

--- a/frontend/src/components/display-card.component.tsx
+++ b/frontend/src/components/display-card.component.tsx
@@ -7,6 +7,7 @@ import { isErrandReadOnly } from '@utils/errand-utils';
 import { useContext, useState } from 'react';
 import { StakeholderFormModal } from './stakeholder-form.component';
 import { CasedataOwnerOrContact } from '@interfaces/stakeholder';
+import { PartyAssetsSection } from './partyassets/partyassets-section.component';
 
 export const DisplayCard: React.FC<{
   person: CasedataOwnerOrContact;
@@ -53,6 +54,13 @@ export const DisplayCard: React.FC<{
             </div>
           </div>
         </div>
+
+        {person.roles.includes(Role.APPLICANT) && person.personId && (
+          <PartyAssetsSection
+            partyId={person.personId}
+            name={`${person.firstName ?? ''} ${person.lastName ?? ''}`.trim()}
+          />
+        )}
 
         {isEditable && !isErrandReadOnly(errand) && (
           <div className="flex flex-col sm:flex-row gap-[1rem] mb-10">

--- a/frontend/src/components/partyassets/partyassets-detail.component.tsx
+++ b/frontend/src/components/partyassets/partyassets-detail.component.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Asset } from '@interfaces/asset';
+import sanitized from '@services/sanitizer-service';
+import { Label, Spinner } from '@sk-web-gui/react';
+import { ResolvedField } from '@utils/schema-utils';
+import { buildValidityText, statusColorOf, statusLabelOf } from './partyassets-utils';
+
+const containsHtml = (value: string): boolean => /<[^>]+>/.test(value);
+
+const Chips: React.FC<{ items: string[] }> = ({ items }) => (
+  <div className="flex flex-wrap gap-6">
+    {items.map((item, i) => (
+      <span
+        key={`${item}-${i}`}
+        className="inline-flex items-center text-small bg-vattjom-background-200 rounded-full px-10 py-4"
+      >
+        {item}
+      </span>
+    ))}
+  </div>
+);
+
+const FieldRow: React.FC<{ field: ResolvedField }> = ({ field }) => (
+  <div>
+    <div className="text-small font-bold text-dark-secondary mb-4">{field.label}</div>
+    {field.items?.length ?
+      <Chips items={field.items} />
+    : containsHtml(field.value) ?
+      <div className="text-base break-words [&_p]:m-0" dangerouslySetInnerHTML={{ __html: sanitized(field.value) }} />
+    : <div className="text-base break-words whitespace-pre-wrap">{field.value}</div>}
+  </div>
+);
+
+/**
+ * Full read-only view of a single asset ("insats"): resource type heading,
+ * status, validity and every resolved schema field plus any flat metadata.
+ */
+export const PartyAssetsDetail: React.FC<{
+  asset: Asset;
+  heading: string;
+  fields: ResolvedField[];
+  loading?: boolean;
+}> = ({ asset, heading, fields, loading }) => {
+  const validity = buildValidityText(asset);
+  const additionalParameters = Object.entries(asset.additionalParameters ?? {}).filter(([, value]) => !!value);
+
+  return (
+    <div className="flex flex-col gap-20">
+      <div>
+        <h3 className="text-md font-bold mb-8">{heading}</h3>
+        <div className="flex items-center gap-12 flex-wrap">
+          {asset.status && (
+            <Label rounded color={statusColorOf(asset.status)}>
+              {statusLabelOf(asset.status)}
+            </Label>
+          )}
+          {validity && <span className="text-small text-dark-secondary">Giltig {validity}</span>}
+        </div>
+      </div>
+
+      {loading && !fields.length && (
+        <div className="flex items-center gap-8 text-small text-dark-secondary">
+          <Spinner size={2} aria-label="Hämtar detaljer" />
+          Hämtar detaljer …
+        </div>
+      )}
+
+      {fields.map((field) => (
+        <FieldRow key={field.key} field={field} />
+      ))}
+
+      {asset.description && <FieldRow field={{ key: 'description', label: 'Beskrivning', value: asset.description }} />}
+      {asset.statusReason && <FieldRow field={{ key: 'statusReason', label: 'Orsak', value: asset.statusReason }} />}
+      {additionalParameters.map(([key, value]) => (
+        <FieldRow key={key} field={{ key, label: key, value }} />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/partyassets/partyassets-modal.component.tsx
+++ b/frontend/src/components/partyassets/partyassets-modal.component.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { Asset } from '@interfaces/asset';
+import LucideIcon from '@sk-web-gui/lucide-icon';
+import { Button, Modal, Spinner, useThemeQueries } from '@sk-web-gui/react';
+import { useEffect, useMemo, useState } from 'react';
+import { useResolvedAssets } from '@hooks/use-resolved-assets';
+import { PartyAssetsDetail } from './partyassets-detail.component';
+import { PartyAssetsRow } from './partyassets-row.component';
+import { assetHeading, buildStatusTabs, sortAssets, StatusFilter } from './partyassets-utils';
+
+const PANE_HEIGHT = 'max-h-[72vh] overflow-y-auto';
+
+/**
+ * Master–detail view of all of a person's assets ("insatser"): status tabs, a
+ * selectable list and a detail pane for the selected insats. On small screens
+ * the list and detail are shown one at a time with a back action.
+ */
+export const PartyAssetsModal: React.FC<{
+  assets: Asset[];
+  loading: boolean;
+  error: boolean;
+  name: string;
+  show: boolean;
+  onClose: () => void;
+}> = ({ assets, loading, error, name, show, onClose }) => {
+  const { isMaxMediumDevice } = useThemeQueries();
+  const { fieldsById, loading: fieldsLoading } = useResolvedAssets(show ? assets : []);
+
+  const [statusTab, setStatusTab] = useState<StatusFilter>('ALL');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showDetailOnMobile, setShowDetailOnMobile] = useState(false);
+
+  const tabs = useMemo(() => buildStatusTabs(assets), [assets]);
+  const listAssets = useMemo(
+    () => sortAssets(statusTab === 'ALL' ? assets : assets.filter((asset) => asset.status === statusTab)),
+    [assets, statusTab]
+  );
+
+  // Reset to the first item (and the list view on mobile) whenever the tab changes.
+  useEffect(() => {
+    setSelectedId(listAssets[0]?.id ?? null);
+    setShowDetailOnMobile(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusTab]);
+
+  // Start on the "Alla" tab each time the modal is opened.
+  useEffect(() => {
+    if (show) setStatusTab('ALL');
+  }, [show]);
+
+  const selectedAsset = listAssets.find((asset) => asset.id === selectedId) ?? listAssets[0] ?? null;
+
+  const selectAsset = (id: string) => {
+    setSelectedId(id);
+    setShowDetailOnMobile(true);
+  };
+
+  const headingFor = (asset: Asset) => assetHeading(asset, fieldsById[asset.id] ?? []);
+
+  const list = (
+    <ul className="flex flex-col gap-8 list-none p-0 m-0" aria-label="Insatser">
+      {listAssets.map((asset) => (
+        <li key={asset.id}>
+          <PartyAssetsRow
+            asset={asset}
+            heading={headingFor(asset)}
+            selected={asset.id === selectedAsset?.id}
+            onSelect={() => selectAsset(asset.id)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+
+  const detail =
+    selectedAsset ?
+      <PartyAssetsDetail
+        asset={selectedAsset}
+        heading={headingFor(selectedAsset)}
+        fields={fieldsById[selectedAsset.id] ?? []}
+        loading={fieldsLoading}
+      />
+    : <p className="text-dark-secondary italic">Välj en insats för att se detaljer.</p>;
+
+  const tabBar = (
+    <div role="tablist" aria-label="Filtrera insatser på status" className="flex gap-8 flex-wrap mb-16">
+      {tabs.map(({ key, label, count }) => (
+        <button
+          key={key}
+          type="button"
+          role="tab"
+          aria-selected={statusTab === key}
+          data-cy={`asset-tab-${key.toLowerCase()}`}
+          onClick={() => setStatusTab(key)}
+          className={`px-12 py-6 rounded-12 text-small whitespace-nowrap ${
+            statusTab === key ?
+              'bg-vattjom-background-200 text-dark-primary font-semibold'
+            : 'text-dark-secondary hover:bg-background-200'
+          }`}
+        >
+          {label} ({count})
+        </button>
+      ))}
+    </div>
+  );
+
+  const body = () => {
+    if (loading) {
+      return (
+        <div className="flex justify-center py-40">
+          <Spinner size={4} aria-label="Hämtar insatser" />
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <p className="text-error py-16" role="alert">
+          Insatserna kunde inte hämtas. Försök igen senare.
+        </p>
+      );
+    }
+    if (!assets.length) {
+      return <p className="text-dark-secondary italic py-16">Inga insatser hittades.</p>;
+    }
+
+    if (isMaxMediumDevice) {
+      return (
+        <div>
+          {tabBar}
+          {showDetailOnMobile ?
+            <div>
+              <Button
+                variant="tertiary"
+                size="sm"
+                className="mb-12"
+                leftIcon={<LucideIcon name="arrow-left" size={16} />}
+                onClick={() => setShowDetailOnMobile(false)}
+              >
+                Tillbaka till listan
+              </Button>
+              {detail}
+            </div>
+          : list}
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {tabBar}
+        <div className="flex gap-20">
+          <div className={`w-[22rem] shrink-0 border-r border-divider pr-12 ${PANE_HEIGHT}`}>{list}</div>
+          <div className={`flex-1 pl-4 ${PANE_HEIGHT}`}>{detail}</div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal
+      show={show}
+      onClose={onClose}
+      label={name ? `Insatser – ${name}` : 'Insatser'}
+      className="w-full max-w-[96rem]"
+    >
+      <Modal.Content>{body()}</Modal.Content>
+    </Modal>
+  );
+};

--- a/frontend/src/components/partyassets/partyassets-row.component.tsx
+++ b/frontend/src/components/partyassets/partyassets-row.component.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Asset } from '@interfaces/asset';
+import { Label } from '@sk-web-gui/react';
+import { buildValidityText, statusColorOf, statusLabelOf } from './partyassets-utils';
+
+export const PartyAssetsRow: React.FC<{
+  heading: string;
+  asset: Asset;
+  selected: boolean;
+  onSelect: () => void;
+}> = ({ heading, asset, selected, onSelect }) => {
+  const validity = buildValidityText(asset);
+
+  return (
+    <button
+      type="button"
+      data-cy="asset-row"
+      onClick={onSelect}
+      aria-current={selected}
+      className={`w-full text-left p-12 rounded-12 border-1 transition-colors ${
+        selected ?
+          'bg-vattjom-background-200 border-vattjom-surface-primary'
+        : 'bg-background-content hover:bg-background-200'
+      }`}
+    >
+      <span className="block font-semibold truncate">{heading}</span>
+      {asset.status && (
+        <Label rounded color={statusColorOf(asset.status)} className="mt-4">
+          {statusLabelOf(asset.status)}
+        </Label>
+      )}
+      {validity && <p className="text-small text-dark-secondary mt-4">Giltig {validity}</p>}
+    </button>
+  );
+};

--- a/frontend/src/components/partyassets/partyassets-section.component.tsx
+++ b/frontend/src/components/partyassets/partyassets-section.component.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { usePartyAssets } from '@services/partyassets-service';
+import LucideIcon from '@sk-web-gui/lucide-icon';
+import { Button, Spinner } from '@sk-web-gui/react';
+import { useState } from 'react';
+import { PartyAssetsModal } from './partyassets-modal.component';
+
+/**
+ * Compact "Insatser" summary for a person card: shows active/total counts and a
+ * button that opens the full insatser view in a modal. Keeps the card clean by
+ * moving the list and details into a dedicated, spacious surface.
+ */
+export const PartyAssetsSection: React.FC<{ partyId: string; name?: string }> = ({ partyId, name }) => {
+  const { assets, loading, error } = usePartyAssets(partyId);
+  const [showModal, setShowModal] = useState(false);
+
+  const total = assets.length;
+  const activeCount = assets.filter((asset) => asset.status === 'ACTIVE').length;
+
+  const action = () => {
+    if (loading) {
+      return <Spinner size={2} aria-label="Hämtar insatser" />;
+    }
+    if (error) {
+      return (
+        <span className="text-small text-error" role="alert">
+          Insatserna kunde inte hämtas
+        </span>
+      );
+    }
+    if (total === 0) {
+      return <span className="text-small text-dark-secondary italic">Inga insatser</span>;
+    }
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        color="vattjom"
+        data-cy="show-assets-button"
+        rightIcon={<LucideIcon name="arrow-right" size={16} />}
+        onClick={() => setShowModal(true)}
+      >
+        Visa insatser
+      </Button>
+    );
+  };
+
+  return (
+    <div className="mt-12 pt-12 pb-20 border-t-1">
+      <div className="flex items-center justify-between gap-12 flex-wrap">
+        <div className="flex items-center gap-8">
+          <LucideIcon name="list-checks" size={18} />
+          <span className="font-semibold">Insatser</span>
+          {!loading && !error && total > 0 && (
+            <span className="text-small text-dark-secondary">
+              {activeCount} aktiva · {total} totalt
+            </span>
+          )}
+        </div>
+
+        {action()}
+      </div>
+
+      <PartyAssetsModal
+        assets={assets}
+        loading={loading}
+        error={error}
+        name={name ?? ''}
+        show={showModal}
+        onClose={() => setShowModal(false)}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/partyassets/partyassets-utils.ts
+++ b/frontend/src/components/partyassets/partyassets-utils.ts
@@ -1,0 +1,65 @@
+import { Asset, AssetStatus, assetStatusColors, assetStatusLabels, assetTypeLabels } from '@interfaces/asset';
+import { ResolvedField } from '@utils/schema-utils';
+import dayjs from 'dayjs';
+
+/** Schema field key that holds the asset's resource type ("Restyp"). */
+const RESTYP_FIELD = 'type';
+
+export type StatusFilter = 'ALL' | AssetStatus;
+
+export const formatDate = (value?: string): string => {
+  if (!value) return '';
+  const date = dayjs(value);
+  return date.isValid() ? date.format('YYYY-MM-DD') : value;
+};
+
+/**
+ * Compact validity text: a date range when time-limited, otherwise "fr.o.m." the
+ * start date (open-ended). Empty when no dates are set.
+ */
+export const buildValidityText = (asset: Pick<Asset, 'issued' | 'validTo'>): string => {
+  const from = formatDate(asset.issued);
+  const to = formatDate(asset.validTo);
+  if (from && to) return `${from} – ${to}`;
+  if (from) return `fr.o.m. ${from}`;
+  return '';
+};
+
+export const statusLabelOf = (status: Asset['status']): string =>
+  assetStatusLabels[status as keyof typeof assetStatusLabels] ?? status;
+
+export const statusColorOf = (status: Asset['status']): string => assetStatusColors[status] ?? 'tertiary';
+
+/**
+ * Card/modal heading: the resolved "Restyp" value when available, otherwise the
+ * asset's type label, falling back to a generic word.
+ */
+export const assetHeading = (asset: Asset, fields: ResolvedField[]): string => {
+  const restyp = fields.find((field) => field.key === RESTYP_FIELD)?.value;
+  if (restyp) return restyp;
+  return assetTypeLabels[asset.type as keyof typeof assetTypeLabels] ?? asset.type ?? 'Insats';
+};
+
+/** Active assets first, then newest first (by issued/valid-from date). */
+export const sortAssets = (assets: Asset[]): Asset[] =>
+  [...assets].sort((a, b) => {
+    const activeRank = (status: Asset['status']) => (status === 'ACTIVE' ? 0 : 1);
+    const rankDiff = activeRank(a.status) - activeRank(b.status);
+    if (rankDiff !== 0) return rankDiff;
+    // ISO dates (YYYY-MM-DD) sort correctly as strings; descending for newest first.
+    return (b.issued ?? '').localeCompare(a.issued ?? '');
+  });
+
+/** Status tabs with counts: "Alla" plus each status that has at least one asset. */
+export const buildStatusTabs = (assets: Asset[]): { key: StatusFilter; label: string; count: number }[] => {
+  // DRAFT is intentionally omitted: drafts are filtered out before reaching here.
+  const statuses: AssetStatus[] = ['ACTIVE', 'TEMPORARY', 'EXPIRED', 'BLOCKED', 'REPLACED'];
+  const tabs: { key: StatusFilter; label: string; count: number }[] = [
+    { key: 'ALL', label: 'Alla', count: assets.length },
+  ];
+  for (const status of statuses) {
+    const count = assets.filter((asset) => asset.status === status).length;
+    if (count > 0) tabs.push({ key: status, label: assetStatusLabels[status], count });
+  }
+  return tabs;
+};

--- a/frontend/src/hooks/use-resolved-assets.ts
+++ b/frontend/src/hooks/use-resolved-assets.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { Asset } from '@interfaces/asset';
+import { getFormSchema } from '@services/jsonschema-service';
+import { resolveSchemaFields, ResolvedField } from '@utils/schema-utils';
+import { useEffect, useState } from 'react';
+
+const resolveAssetFields = async (asset: Asset): Promise<ResolvedField[]> => {
+  const perParameter = await Promise.all(
+    (asset.jsonParameters ?? []).map(async (param) => {
+      try {
+        const { schema, uiSchema } = await getFormSchema(param.schemaId);
+        return resolveSchemaFields(schema, uiSchema, param.value);
+      } catch {
+        return resolveSchemaFields(null, null, param.value);
+      }
+    })
+  );
+  return perParameter.flat();
+};
+
+/**
+ * Loads schemas for every asset's json parameters and resolves their stored
+ * values into human-readable fields, keyed by asset id. Schema fetches are
+ * deduplicated/cached, so assets sharing a schema only fetch it once. When a
+ * schema can't be loaded the raw values are still resolved, so data is never
+ * silently dropped.
+ */
+export const useResolvedAssets = (
+  assets: Asset[]
+): { fieldsById: Record<string, ResolvedField[]>; loading: boolean } => {
+  const [fieldsById, setFieldsById] = useState<Record<string, ResolvedField[]>>({});
+  const [loading, setLoading] = useState(false);
+
+  const key = assets.map((asset) => asset.id).join(',');
+
+  useEffect(() => {
+    const withParameters = assets.filter((asset) => asset.jsonParameters?.length);
+    if (!withParameters.length) {
+      setFieldsById({});
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all(withParameters.map(async (asset) => [asset.id, await resolveAssetFields(asset)] as const)).then(
+      (entries) => {
+        if (cancelled) return;
+        setFieldsById(Object.fromEntries(entries));
+        setLoading(false);
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return { fieldsById, loading };
+};

--- a/frontend/src/interfaces/asset.ts
+++ b/frontend/src/interfaces/asset.ts
@@ -1,13 +1,37 @@
-export type AssetStatus = 'ACTIVE' | 'EXPIRED' | 'BLOCKED';
+export type AssetStatus = 'ACTIVE' | 'DRAFT' | 'EXPIRED' | 'BLOCKED' | 'TEMPORARY' | 'REPLACED';
 export enum assetStatusLabels {
   ACTIVE = 'Aktivt',
+  DRAFT = 'Utkast',
   EXPIRED = 'Utgånget',
   BLOCKED = 'Blockerat',
+  TEMPORARY = 'Tillfälligt',
+  REPLACED = 'Ersatt',
 }
 
 export enum assetTypeLabels {
   PARKINGPERMIT = 'P-tillstånd',
 }
+
+/** Maps an asset status to a `@sk-web-gui` Label color token. */
+export const assetStatusColors: Record<AssetStatus, string> = {
+  ACTIVE: 'gronsta',
+  DRAFT: 'tertiary',
+  EXPIRED: 'tertiary',
+  BLOCKED: 'warning',
+  TEMPORARY: 'vattjom',
+  REPLACED: 'tertiary',
+};
+/**
+ * A schema-bound blob of structured data stored on an asset. `value` holds the
+ * form data (validated against the schema identified by `schemaId`) and is what
+ * we resolve into human-readable fields when displaying an asset.
+ */
+export interface AssetJsonParameter {
+  key: string;
+  value: Record<string, unknown>;
+  schemaId: string;
+}
+
 export interface Asset {
   id: string;
   assetId: string;
@@ -21,6 +45,7 @@ export interface Asset {
   statusReason: string;
   description: string;
   additionalParameters: { [key: string]: string };
+  jsonParameters?: AssetJsonParameter[];
 }
 
 export interface UpdateAsset {

--- a/frontend/src/services/jsonschema-service.ts
+++ b/frontend/src/services/jsonschema-service.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { ApiResponse, apiService } from '@services/api-service';
+
+/** A JSON Schema document and its optional ui-schema, as returned by the backend. */
+export interface FormSchema {
+  schema: Record<string, unknown>;
+  uiSchema: Record<string, unknown>;
+  schemaId: string;
+}
+
+/**
+ * Schemas are immutable per id, so we cache the in-flight/resolved promise per
+ * `schemaId` to avoid refetching the same schema for every asset that uses it.
+ */
+const schemaCache = new Map<string, Promise<FormSchema>>();
+
+/**
+ * Fetch (and cache) a JSON schema by id. Used to resolve the labels and enum
+ * titles of an asset's `jsonParameters`.
+ */
+export const getFormSchema = (schemaId: string): Promise<FormSchema> => {
+  const cached = schemaCache.get(schemaId);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = apiService
+    .get<ApiResponse<FormSchema>>(`schemas/${schemaId}`)
+    .then((res) => res.data.data)
+    .catch((e) => {
+      schemaCache.delete(schemaId);
+      throw e;
+    });
+
+  schemaCache.set(schemaId, promise);
+  return promise;
+};

--- a/frontend/src/services/partyassets-service.ts
+++ b/frontend/src/services/partyassets-service.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { Asset } from '@interfaces/asset';
+import { ApiResponse, apiService } from '@services/api-service';
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Assets in `DRAFT` status are being worked on in another errand and must never
+ * be shown here. The PartyAssets `/assets` endpoint already omits them, but we
+ * guard defensively in case that ever changes.
+ */
+const DRAFT_STATUS = 'DRAFT';
+
+export interface PartyAssetsState {
+  assets: Asset[];
+  loading: boolean;
+  error: boolean;
+}
+
+/**
+ * Fetch the assets ("insatser") registered for a given party/person.
+ *
+ * @param partyId The party (person) identifier, i.e. the `personId` resolved
+ *   through the citizen search. Returns an empty list when missing.
+ */
+export const getPartyAssets = async (partyId: string): Promise<Asset[]> => {
+  if (!partyId) {
+    return [];
+  }
+
+  const res = await apiService.get<ApiResponse<Asset[]>>(`partyassets/assets/${partyId}`);
+  return (res.data.data ?? []).filter((asset) => (asset.status as string) !== DRAFT_STATUS);
+};
+
+/**
+ * React hook that loads a party's assets and tracks loading/error state.
+ * Re-fetches whenever `partyId` changes.
+ */
+export const usePartyAssets = (partyId?: string): PartyAssetsState & { refetch: () => void } => {
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fetchAssets = useCallback(async () => {
+    if (!partyId) {
+      setAssets([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(false);
+
+    try {
+      setAssets(await getPartyAssets(partyId));
+    } catch {
+      setError(true);
+      setAssets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [partyId]);
+
+  useEffect(() => {
+    fetchAssets();
+  }, [fetchAssets]);
+
+  return { assets, loading, error, refetch: fetchAssets };
+};

--- a/frontend/src/utils/schema-utils.ts
+++ b/frontend/src/utils/schema-utils.ts
@@ -1,0 +1,87 @@
+type JsonSchema = Record<string, unknown>;
+type OneOf = Array<{ const?: string; title?: string }>;
+
+export interface ResolvedField {
+  key: string;
+  label: string;
+  /** Display string (enum/array values joined). Always set. */
+  value: string;
+  /** Present for array/enum-list fields so they can be rendered as chips. */
+  items?: string[];
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
+
+const propertyOf = (schema: JsonSchema | null, field: string): Record<string, unknown> | undefined =>
+  asRecord(asRecord(schema?.properties)?.[field]);
+
+/** The `oneOf` enum options of a (possibly array-item) field, if any. */
+const oneOfOf = (fieldSchema: Record<string, unknown> | undefined, fromItems: boolean): OneOf | undefined => {
+  const source = fromItems ? asRecord(fieldSchema?.items) : fieldSchema;
+  return source?.oneOf as OneOf | undefined;
+};
+
+/** Resolve a single enum value to its schema title, falling back to the raw value. */
+export function enumTitleOf(schema: JsonSchema | null, field: string, value: string): string {
+  if (!schema || !value) return value ?? '';
+  const oneOf = oneOfOf(propertyOf(schema, field), false);
+  return oneOf?.find((o) => o.const === value)?.title ?? value;
+}
+
+/** Resolve an array of enum values to their schema titles. */
+export function enumTitlesOfArray(schema: JsonSchema | null, field: string, values: string[] = []): string[] {
+  const oneOf = oneOfOf(propertyOf(schema, field), true);
+  if (!oneOf) return values ?? [];
+  return (values ?? []).map((v) => oneOf.find((o) => o.const === v)?.title ?? v);
+}
+
+const isEmpty = (value: unknown): boolean =>
+  value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
+
+const labelOf = (schema: JsonSchema | null, uiSchema: JsonSchema | null, key: string): string => {
+  const uiTitle = asRecord(uiSchema?.[key])?.['ui:title'];
+  if (typeof uiTitle === 'string' && uiTitle) return uiTitle;
+  const schemaTitle = propertyOf(schema, key)?.title;
+  return typeof schemaTitle === 'string' && schemaTitle ? schemaTitle : key;
+};
+
+const resolveValue = (schema: JsonSchema | null, key: string, value: unknown): { value: string; items?: string[] } => {
+  if (Array.isArray(value)) {
+    const items = enumTitlesOfArray(
+      schema,
+      key,
+      value.map((v) => String(v))
+    );
+    return { value: items.join(', '), items };
+  }
+  if (typeof value === 'boolean') return { value: value ? 'Ja' : 'Nej' };
+  if (value && typeof value === 'object') return { value: JSON.stringify(value) };
+  return { value: enumTitleOf(schema, key, String(value)) };
+};
+
+/**
+ * Resolve a `jsonParameter.value` blob into an ordered list of human-readable
+ * fields using its schema (labels + enum titles) and ui-schema (`ui:order`,
+ * `ui:title`). Empty values are skipped. Falls back to raw keys/values when the
+ * schema is missing, so data is always shown even without a resolvable schema.
+ */
+export function resolveSchemaFields(
+  schema: JsonSchema | null,
+  uiSchema: JsonSchema | null,
+  data: Record<string, unknown> | null | undefined
+): ResolvedField[] {
+  if (!data) return [];
+
+  const order = uiSchema?.['ui:order'];
+  const orderedKeys = Array.isArray(order) ? (order as string[]).filter((k) => k in data) : [];
+  const remainingKeys = Object.keys(data).filter((k) => !orderedKeys.includes(k));
+
+  return [...orderedKeys, ...remainingKeys]
+    .filter((key) => !isEmpty(data[key]))
+    .map((key) => ({
+      key,
+      label: labelOf(schema, uiSchema, key),
+      ...resolveValue(schema, key, data[key]),
+    }));
+}


### PR DESCRIPTION
> **Staplad PR** — riktad mot `fix/swagger-contract-generation` eftersom featuren beror på det genererade `partyassets`-kontraktet. När swagger-PR:en mergats till `develop` retargetas den här automatiskt till `develop`.

## Vad

Visar en stakeholders insatser (party assets) på den sökandes kort i ärendevyn.

## Funktionalitet

- **`DisplayCard`** får en kompakt **Insatser**-sammanfattning (antal aktiva/totalt) med en knapp som öppnar en modal. Visas bara för stakeholders med rollen `APPLICANT` och ett `personId`.
- **Modal i master–detail**: status-flikar med antal, en valbar lista och en read-only detaljpanel. På små skärmar visas lista och detalj en i taget med en "Tillbaka"-åtgärd.
- **Schema-resolvering**: en asses `jsonParameters` resolvas till läsbara fält (etiketter + enum-titlar) via JSON-schema. Schemahämtningar cachas per `schemaId`. Om ett schema inte kan laddas visas råvärdena ändå — data tappas aldrig tyst.

## Struktur / ansvar

- Backend: tunna proxy-controllers `PartyAssetsController` och `SchemaController` (+ `jsonschema`-API i config, controller-registrering i `server.ts`).
- Frontend: rena formaterings-/sorteringsfunktioner i `partyassets-utils`, schema-resolveringen isolerad i hooken `useResolvedAssets` (`@hooks/use-resolved-assets`) för återanvändning, och `schema-utils` som fristående rena funktioner.
- `DRAFT`-assets filtreras bort (de tillhör andra ärenden).

## Verifiering

- `tsc --noEmit` rent i både frontend och backend.

Jira: https://jira.sundsvall.se/browse/DRAKEN-4308
