### PR TITLE
feat: visa Medicinskt utlåtande endast för katla-färdtjänstkanalen

### DIFF
--- a/frontend/src/components/errandinformation/external-circumstances.component.tsx
+++ b/frontend/src/components/errandinformation/external-circumstances.component.tsx
@@ -1,6 +1,7 @@
 import { ErrandDisclosure } from '@components/errand-disclosures/errand-disclosure.component';
 import { buildRenderableFields } from '@components/field-rendering/renderable-fields';
 import { AppContext } from '@contexts/app-context-interface';
+import { Channels } from '@interfaces/channels';
 import { IErrand } from '@interfaces/errand';
 import {
   EXTRAPARAMETER_SEPARATOR,
@@ -23,7 +24,12 @@ export const ExternalCircumstances: React.FC = () => {
       caseType: caseType || '',
       extraParameters: errand?.extraParameters ?? [],
     });
-    const f = caseType ? (uppgifter[caseType] ?? []).filter((f) => f.section === 'Yttre omständigheter') : [];
+    // För andra kanaler än katla-färdtjänsten lever även "Medicinskt utlåtande"-fälten
+    // under "Yttre omständigheter" (den egna medicinska sektionen visas då inte).
+    const isKatlaChannel = errand?.channel === Channels.ESERVICE_KATLA;
+    const sectionsToShow =
+      isKatlaChannel ? ['Yttre omständigheter'] : ['Yttre omständigheter', 'Medicinskt utlåtande'];
+    const f = caseType ? (uppgifter[caseType] ?? []).filter((f) => sectionsToShow.includes(f.section)) : [];
     setFields(f);
 
     f?.forEach((f) => {

--- a/frontend/src/components/errandinformation/medical-opinion.component.tsx
+++ b/frontend/src/components/errandinformation/medical-opinion.component.tsx
@@ -1,6 +1,7 @@
 import { ErrandDisclosure } from '@components/errand-disclosures/errand-disclosure.component';
 import { buildRenderableFields } from '@components/field-rendering/renderable-fields';
 import { AppContext } from '@contexts/app-context-interface';
+import { Channels } from '@interfaces/channels';
 import { IErrand } from '@interfaces/errand';
 import { Priority } from '@interfaces/priority';
 import {
@@ -86,7 +87,12 @@ export const MedicalOpinion: React.FC = () => {
     [fields]
   );
 
-  if (fields.length === 0) {
+  // Visa "Medicinskt utlåtande" som egen sektion endast när ärendet kommit in via
+  // katla-färdtjänsten. För övriga kanaler visas fälten i stället under "Yttre omständigheter".
+  // Hooks ovan körs fortfarande (default-värden + palliativ prioritetslogik) oavsett kanal.
+  const isKatlaChannel = errand?.channel === Channels.ESERVICE_KATLA;
+
+  if (fields.length === 0 || !isKatlaChannel) {
     return null;
   }
 


### PR DESCRIPTION
## Vad
Sektionen **Medicinskt utlåtande** visas nu som egen sektion endast när ärendet kommit in via katla-färdtjänsten (kanal `ESERVICE_KATLA` = "E-tjänst Färdtjänstregistrering"). För övriga kanaler visas de medicinska fälten i stället under **Yttre omständigheter**.

## Varför
För ärenden som inte kommer via katla-färdtjänsten ska medicinsk utlåtande-information inte ha en egen sektion utan leva tillsammans med yttre omständigheter.

## Ändringar
- `medical-opinion.component.tsx`: Returnerar `null` (döljer sektionen) när `errand.channel !== Channels.ESERVICE_KATLA`. Den tidiga `return` ligger efter alla hooks, så default-värden och palliativ-logiken (`PALLIATIVE_CARE` → hög prioritet) körs fortfarande oavsett kanal.
- `external-circumstances.component.tsx`: När kanalen inte är katla inkluderas både `Yttre omständigheter`- och `Medicinskt utlåtande`-fälten (externa fält först, sedan medicinska enligt mallens ordning).

## Resultat
- **Kanal = katla-färdtjänsten** → `Yttre omständigheter` (egna fält) + separat `Medicinskt utlåtande`-sektion, som tidigare.
- **Övriga kanaler** → ingen separat medicinsk sektion; alla värden ligger under `Yttre omständigheter`.

## Testning
- `npx tsc --noEmit` – inga typfel i de ändrade filerna.